### PR TITLE
Use get_url module, apt-key doesn't exist anymore on trixie

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,12 +7,12 @@
     state: present
 
 - name: Add Elasticsearch apt key.
-  apt_key:
+  get_url:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-    state: present
+    dest: /etc/apt/keyrings/artifacts.elastic.co.asc
 
 - name: Add Elasticsearch repository.
   apt_repository:
-    repo: 'deb https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
+    repo: 'deb [signed-by=/etc/apt/keyrings/artifacts.elastic.co.asc] https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
     state: present
     update_cache: true


### PR DESCRIPTION
while here set signed-by on the repository to point at the signing key